### PR TITLE
Add err.h

### DIFF
--- a/client.c
+++ b/client.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <arpa/inet.h> 
+#include <err.h>
 
 #define MAX_MSG_SIZE 1024
 


### PR DESCRIPTION
err() function returns error if err.h file is not included.